### PR TITLE
Fix task generator reference in README

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -66,7 +66,7 @@ This project uses the [AI Dev Tasks for Cursor](https://github.com/snarktank/ai-
 ### Development Phases:
 
 1. **PRD Creation** – Create a detailed Product Requirement Document using `create-prd.mdc`.
-2. **Task Generation** – Break the PRD into a step-by-step implementation plan using `generate-tasks-from-prd.mdc`.
+2. **Task Generation** – Break the PRD into a step-by-step implementation plan using `generate-tasks.mdc`.
 3. **Task Execution** – Guide the AI to complete tasks one-by-one with `process-task-list.mdc`.
 4. **Approval & Iteration** – Review each task’s output, provide feedback or approve.
 5. **Progress Tracking** – Visually track which features are done and what’s next.


### PR DESCRIPTION
## Summary
- update README to point to `generate-tasks.mdc`

## Testing
- `npx jest` *(fails: Could not find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_683fb41833648321a894712e036a8832