### PR TITLE
Implement HexGrid overlay

### DIFF
--- a/src/components/GameBoard.test.tsx
+++ b/src/components/GameBoard.test.tsx
@@ -7,4 +7,5 @@ test('renders game board with background image', () => {
   const board = getByTestId('game-board');
   expect(board).toBeInTheDocument();
   expect(board.style.backgroundImage).not.toBe('');
+  expect(getByTestId('hex-grid')).toBeInTheDocument();
 });

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import boardImage from '../../assets/img/climate-hero-board.png';
+import HexGrid from './HexGrid';
 import './GameBoard.css';
 
 const GameBoard: React.FC = () => {
@@ -8,7 +9,9 @@ const GameBoard: React.FC = () => {
       className="game-board"
       data-testid="game-board"
       style={{ backgroundImage: `url(${boardImage})` }}
-    />
+    >
+      <HexGrid />
+    </div>
   );
 };
 

--- a/src/components/HexGrid.css
+++ b/src/components/HexGrid.css
@@ -1,0 +1,8 @@
+.hex-grid {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}

--- a/src/components/HexGrid.tsx
+++ b/src/components/HexGrid.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import './HexGrid.css';
+
+const HexGrid: React.FC = () => {
+  return (
+    <svg className="hex-grid" data-testid="hex-grid" viewBox="0 0 800 600" width="800" height="600">
+      <defs>
+        <pattern id="hexPattern" width="60" height="52" patternUnits="userSpaceOnUse" patternTransform="translate(30,26)"
+        >
+          <polygon points="30,0 60,15 60,45 30,60 0,45 0,15" fill="none" stroke="rgba(0,0,0,0.2)" strokeWidth="1" />
+        </pattern>
+      </defs>
+      <rect width="800" height="600" fill="url(#hexPattern)" />
+    </svg>
+  );
+};
+
+export default HexGrid;

--- a/tasks/tasks-prd-base-gameboard-setup-token-movement.md
+++ b/tasks/tasks-prd-base-gameboard-setup-token-movement.md
@@ -3,6 +3,7 @@
 - `src/components/GameBoard.tsx` - Renders the map background with a hex grid overlay.
 - `src/components/GameBoard.css` - Styling for the GameBoard background image.
 - `src/components/HexGrid.tsx` - Logic for drawing and managing the hex grid.
+- `src/components/HexGrid.css` - Styling for the hex grid overlay.
 - `src/components/Token.tsx` - Draggable token component snapped to grid centers.
 - `src/components/GameBoard.test.tsx` - Unit tests for the GameBoard component.
 - `src/components/Token.test.tsx` - Unit tests for token drag and drop behaviour.
@@ -16,7 +17,7 @@
 
 - [ ] 1.0 Create interactive game board
   - [x] 1.1 Build `GameBoard` component with background image
-  - [ ] 1.2 Implement `HexGrid` overlay within the board
+  - [x] 1.2 Implement `HexGrid` overlay within the board
   - [ ] 1.3 Render `GameBoard` in `App`
 - [ ] 2.0 Implement draggable tokens
   - [ ] 2.1 Build `Token` component displaying hero icons


### PR DESCRIPTION
## Summary
- add `HexGrid` component and styles
- integrate hex grid overlay in `GameBoard`
- test for hex grid presence
- document progress in task list

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_683fc2705a608321b594acfeb16a1487