### PR TITLE
Render game board within App

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from './App';
+
+test('renders GameBoard component inside App', () => {
+  const { getByTestId } = render(<App />);
+  const board = getByTestId('game-board');
+  expect(board).toBeInTheDocument();
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
+import GameBoard from './components/GameBoard';
 
 export default function App() {
-  return <h1>Pacific Climate Heroes</h1>;
+  return (
+    <div>
+      <h1>Pacific Climate Heroes</h1>
+      <GameBoard />
+    </div>
+  );
 }

--- a/tasks/tasks-prd-base-gameboard-setup-token-movement.md
+++ b/tasks/tasks-prd-base-gameboard-setup-token-movement.md
@@ -17,7 +17,7 @@
 - [ ] 1.0 Create interactive game board
   - [x] 1.1 Build `GameBoard` component with background image
   - [ ] 1.2 Implement `HexGrid` overlay within the board
-  - [ ] 1.3 Render `GameBoard` in `App`
+  - [x] 1.3 Render `GameBoard` in `App`
 - [ ] 2.0 Implement draggable tokens
   - [ ] 2.1 Build `Token` component displaying hero icons
   - [ ] 2.2 Enable drag-and-drop behaviour using React state


### PR DESCRIPTION
## Summary
- display the main GameBoard component inside `App`
- add unit test verifying `GameBoard` renders in `App`
- mark task 1.3 complete in the task list

## Testing
- `npm install`
- `npx --yes jest`

------
https://chatgpt.com/codex/tasks/task_e_683fc2878d78832182db994e8de6ac21