### PR TITLE
Add hero token component

### DIFF
--- a/assets/img/hero-icon.svg
+++ b/assets/img/hero-icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <circle cx="32" cy="32" r="30" fill="#0099ff" stroke="black" stroke-width="2" />
+  <text x="32" y="38" font-size="32" text-anchor="middle" fill="white">H</text>
+</svg>

--- a/src/components/Token.css
+++ b/src/components/Token.css
@@ -1,0 +1,6 @@
+.token {
+  width: 64px;
+  height: 64px;
+  cursor: pointer;
+  user-select: none;
+}

--- a/src/components/Token.test.tsx
+++ b/src/components/Token.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Token from './Token';
+import heroIcon from '../../assets/img/hero-icon.svg';
+
+test('renders token image', () => {
+  const { getByTestId } = render(<Token icon={heroIcon} alt="Hero" />);
+  const token = getByTestId('token') as HTMLImageElement;
+  expect(token).toBeInTheDocument();
+  expect(token.alt).toBe('Hero');
+});

--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import './Token.css';
+
+export interface TokenProps {
+  icon: string;
+  alt?: string;
+}
+
+const Token: React.FC<TokenProps> = ({ icon, alt = 'token' }) => {
+  return <img src={icon} alt={alt} className="token" data-testid="token" />;
+};
+
+export default Token;

--- a/tasks/tasks-prd-base-gameboard-setup-token-movement.md
+++ b/tasks/tasks-prd-base-gameboard-setup-token-movement.md
@@ -4,8 +4,10 @@
 - `src/components/GameBoard.css` - Styling for the GameBoard background image.
 - `src/components/HexGrid.tsx` - Logic for drawing and managing the hex grid.
 - `src/components/Token.tsx` - Draggable token component snapped to grid centers.
+- `src/components/Token.css` - Base styling for token images.
 - `src/components/GameBoard.test.tsx` - Unit tests for the GameBoard component.
 - `src/components/Token.test.tsx` - Unit tests for token drag and drop behaviour.
+- `assets/img/hero-icon.svg` - Placeholder hero icon for tokens.
 
 ### Notes
 
@@ -19,7 +21,7 @@
   - [ ] 1.2 Implement `HexGrid` overlay within the board
   - [ ] 1.3 Render `GameBoard` in `App`
 - [ ] 2.0 Implement draggable tokens
-  - [ ] 2.1 Build `Token` component displaying hero icons
+  - [x] 2.1 Build `Token` component displaying hero icons
   - [ ] 2.2 Enable drag-and-drop behaviour using React state
   - [ ] 2.3 Snap tokens to nearest hex on drop
 - [ ] 3.0 Constrain token movement to board bounds


### PR DESCRIPTION
## Summary
- create Token component with basic styles
- add placeholder hero icon
- test token rendering
- update task list for task 2.1

## Testing
- `npm ci`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_683fc2ac06e48321946fbd4e5444e417