### PR TITLE
Add draggable token and show game board

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
+import GameBoard from './components/GameBoard';
 
 export default function App() {
-  return <h1>Pacific Climate Heroes</h1>;
+  return <GameBoard />;
 }

--- a/src/components/GameBoard.css
+++ b/src/components/GameBoard.css
@@ -1,6 +1,6 @@
 .game-board {
-  width: 800px;
-  height: 600px;
+  width: 100vw;
+  height: 100vh;
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,16 +1,42 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import boardImage from '../../assets/img/climate-hero-board.png';
+import heroIcon from '../../assets/img/hero-icon.svg';
 import HexGrid from './HexGrid';
+import Token from './Token';
 import './GameBoard.css';
 
 const GameBoard: React.FC = () => {
+  const [tokenPos, setTokenPos] = useState({ x: 100, y: 100 });
+  const [dragging, setDragging] = useState(false);
+  const boardRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    setDragging(true);
+    e.preventDefault();
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!dragging || !boardRef.current) return;
+    const rect = boardRef.current.getBoundingClientRect();
+    const x = e.clientX - rect.left - 32;
+    const y = e.clientY - rect.top - 32;
+    setTokenPos({ x, y });
+  };
+
+  const handleMouseUp = () => setDragging(false);
+
   return (
     <div
+      ref={boardRef}
       className="game-board"
       data-testid="game-board"
       style={{ backgroundImage: `url(${boardImage})` }}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
     >
       <HexGrid />
+      <Token icon={heroIcon} x={tokenPos.x} y={tokenPos.y} onMouseDown={handleMouseDown} />
     </div>
   );
 };

--- a/src/components/Token.css
+++ b/src/components/Token.css
@@ -3,4 +3,5 @@
   height: 64px;
   cursor: pointer;
   user-select: none;
+  position: absolute;
 }

--- a/src/components/Token.test.tsx
+++ b/src/components/Token.test.tsx
@@ -4,7 +4,9 @@ import Token from './Token';
 import heroIcon from '../../assets/img/hero-icon.svg';
 
 test('renders token image', () => {
-  const { getByTestId } = render(<Token icon={heroIcon} alt="Hero" />);
+  const { getByTestId } = render(
+    <Token icon={heroIcon} alt="Hero" x={0} y={0} />
+  );
   const token = getByTestId('token') as HTMLImageElement;
   expect(token).toBeInTheDocument();
   expect(token.alt).toBe('Hero');

--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -4,10 +4,22 @@ import './Token.css';
 export interface TokenProps {
   icon: string;
   alt?: string;
+  x: number;
+  y: number;
+  onMouseDown?: (e: React.MouseEvent) => void;
 }
 
-const Token: React.FC<TokenProps> = ({ icon, alt = 'token' }) => {
-  return <img src={icon} alt={alt} className="token" data-testid="token" />;
+const Token: React.FC<TokenProps> = ({ icon, alt = 'token', x, y, onMouseDown }) => {
+  return (
+    <img
+      src={icon}
+      alt={alt}
+      className="token"
+      data-testid="token"
+      style={{ left: x, top: y }}
+      onMouseDown={onMouseDown}
+    />
+  );
 };
 
 export default Token;

--- a/tasks/tasks-prd-base-gameboard-setup-token-movement.md
+++ b/tasks/tasks-prd-base-gameboard-setup-token-movement.md
@@ -20,10 +20,10 @@
 - [ ] 1.0 Create interactive game board
   - [x] 1.1 Build `GameBoard` component with background image
   - [x] 1.2 Implement `HexGrid` overlay within the board
-  - [ ] 1.3 Render `GameBoard` in `App`
+  - [x] 1.3 Render `GameBoard` in `App`
 - [ ] 2.0 Implement draggable tokens
   - [x] 2.1 Build `Token` component displaying hero icons
-  - [ ] 2.2 Enable drag-and-drop behaviour using React state
+  - [x] 2.2 Enable drag-and-drop behaviour using React state
   - [ ] 2.3 Snap tokens to nearest hex on drop
 - [ ] 3.0 Constrain token movement to board bounds
   - [ ] 3.1 Detect board boundaries when tokens are moved


### PR DESCRIPTION
## Summary
- render `GameBoard` from `App`
- make `GameBoard` full screen and include a draggable token
- allow `Token` to receive position and mouse handlers
- update unit tests
- mark completed tasks in task list

## Testing
- `npm install --no-fund --no-audit`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_683fd0ad2288832194a40343e7347954