### PR TITLE
Align visual hex grid with snapping

### DIFF
--- a/src/components/GameBoard.test.tsx
+++ b/src/components/GameBoard.test.tsx
@@ -59,3 +59,30 @@ test('detects when token moves out of bounds', () => {
 
   expect(token.getAttribute('data-out-of-bounds')).toBe('true');
 });
+
+test('scales snapping when board size changes', () => {
+  const { getByTestId } = render(<GameBoard />);
+  const board = getByTestId('game-board');
+  const token = getByTestId('token');
+
+  jest.spyOn(board, 'getBoundingClientRect').mockReturnValue({
+    left: 0,
+    top: 0,
+    right: 1600,
+    bottom: 1200,
+    width: 1600,
+    height: 1200,
+    x: 0,
+    y: 0,
+    toJSON: () => {}
+  });
+
+  fireEvent.mouseDown(token);
+  fireEvent.mouseMove(board, { clientX: 280, clientY: 240 });
+  fireEvent.mouseUp(board);
+
+  const left = parseInt(token.style.left, 10);
+  const top = parseInt(token.style.top, 10);
+  expect(left).toBe(268);
+  expect(top).toBe(228);
+});

--- a/src/components/GameBoard.tsx
+++ b/src/components/GameBoard.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 import boardImage from '../../assets/img/climate-hero-board.png';
 import heroIcon from '../../assets/img/hero-icon.svg';
-import HexGrid from './HexGrid';
+import HexGrid, { HexGridProps } from './HexGrid';
 import Token from './Token';
 import './GameBoard.css';
 
@@ -10,6 +10,30 @@ const GameBoard: React.FC = () => {
   const [dragging, setDragging] = useState(false);
   const [outOfBounds, setOutOfBounds] = useState(false);
   const boardRef = useRef<HTMLDivElement>(null);
+
+  const BASE_GRID: HexGridProps = {
+    width: 800,
+    height: 600,
+    hexWidth: 60,
+    hexHeight: 52,
+    offsetX: 30,
+    offsetY: 26
+  };
+
+  const getGridConfig = (): HexGridProps => {
+    if (!boardRef.current) return BASE_GRID;
+    const rect = boardRef.current.getBoundingClientRect();
+    const scaleX = rect.width / BASE_GRID.width;
+    const scaleY = rect.height / BASE_GRID.height;
+    return {
+      width: rect.width,
+      height: rect.height,
+      hexWidth: BASE_GRID.hexWidth * scaleX,
+      hexHeight: BASE_GRID.hexHeight * scaleY,
+      offsetX: BASE_GRID.offsetX * scaleX,
+      offsetY: BASE_GRID.offsetY * scaleY
+    };
+  };
 
   const handleMouseDown = (e: React.MouseEvent) => {
     setDragging(true);
@@ -38,15 +62,12 @@ const GameBoard: React.FC = () => {
   };
 
   const snapToHex = (x: number, y: number) => {
-    const HEX_WIDTH = 60;
-    const HEX_HEIGHT = 52;
-    const OFFSET_X = 30;
-    const OFFSET_Y = 26;
+    const { hexWidth, hexHeight, offsetX, offsetY } = getGridConfig();
 
     const centerX = x + 32;
     const centerY = y + 32;
-    const gridX = Math.round((centerX - OFFSET_X) / HEX_WIDTH) * HEX_WIDTH + OFFSET_X;
-    const gridY = Math.round((centerY - OFFSET_Y) / HEX_HEIGHT) * HEX_HEIGHT + OFFSET_Y;
+    const gridX = Math.round((centerX - offsetX) / hexWidth) * hexWidth + offsetX;
+    const gridY = Math.round((centerY - offsetY) / hexHeight) * hexHeight + offsetY;
     return { x: gridX - 32, y: gridY - 32 };
   };
 
@@ -65,7 +86,7 @@ const GameBoard: React.FC = () => {
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
     >
-      <HexGrid />
+      <HexGrid {...getGridConfig()} />
       <Token
         icon={heroIcon}
         x={tokenPos.x}

--- a/src/components/HexGrid.tsx
+++ b/src/components/HexGrid.tsx
@@ -1,16 +1,57 @@
 import React from 'react';
 import './HexGrid.css';
 
-const HexGrid: React.FC = () => {
+export interface HexGridProps {
+  width: number;
+  height: number;
+  hexWidth: number;
+  hexHeight: number;
+  offsetX: number;
+  offsetY: number;
+}
+
+const HexGrid: React.FC<HexGridProps> = ({
+  width,
+  height,
+  hexWidth,
+  hexHeight,
+  offsetX,
+  offsetY
+}) => {
+  const scale = hexWidth / 60;
+  const points = `
+    ${30 * scale},0 
+    ${60 * scale},${15 * scale} 
+    ${60 * scale},${45 * scale} 
+    ${30 * scale},${60 * scale} 
+    0,${45 * scale} 
+    0,${15 * scale}`.replace(/\s+/g, ' ').trim();
+
   return (
-    <svg className="hex-grid" data-testid="hex-grid" viewBox="0 0 800 600" width="800" height="600">
+    <svg
+      className="hex-grid"
+      data-testid="hex-grid"
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+    >
       <defs>
-        <pattern id="hexPattern" width="60" height="52" patternUnits="userSpaceOnUse" patternTransform="translate(30,26)"
+        <pattern
+          id="hexPattern"
+          width={hexWidth}
+          height={hexHeight}
+          patternUnits="userSpaceOnUse"
+          patternTransform={`translate(${offsetX},${offsetY})`}
         >
-          <polygon points="30,0 60,15 60,45 30,60 0,45 0,15" fill="none" stroke="rgba(0,0,0,0.2)" strokeWidth="1" />
+          <polygon
+            points={points}
+            fill="none"
+            stroke="rgba(0,0,0,0.2)"
+            strokeWidth="1"
+          />
         </pattern>
       </defs>
-      <rect width="800" height="600" fill="url(#hexPattern)" />
+      <rect width={width} height={height} fill="url(#hexPattern)" />
     </svg>
   );
 };


### PR DESCRIPTION
## Summary
- pass dynamic hex sizing from GameBoard to HexGrid
- compute grid scaling from board bounds
- update GameBoard tests to cover scaling

## Testing
- `npm install`
- `npx -y jest`


------
https://chatgpt.com/codex/tasks/task_e_683fd7d6fed08321ab95f50e479b93f5